### PR TITLE
Fix: Set urql client requestPolicy to network-only to prevent stale data

### DIFF
--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -9,9 +9,7 @@ export const getClient = (endpoint: string) => {
     client = new Client({
       url: endpoint,
       exchanges: [cacheExchange, fetchExchange],
-      fetchOptions: {
-        requestPolicy: 'network-only',
-      },
+      requestPolicy: "network-only",
     });
     clients.set(endpoint, client);
   }

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -9,6 +9,9 @@ export const getClient = (endpoint: string) => {
     client = new Client({
       url: endpoint,
       exchanges: [cacheExchange, fetchExchange],
+      fetchOptions: {
+        requestPolicy: 'network-only',
+      },
     });
     clients.set(endpoint, client);
   }


### PR DESCRIPTION
You were experiencing out-of-date views due to the default caching behavior of the urql GraphQL client (`cacheExchange`).

This change modifies the client initialization in `src/app/api/utils.ts` to use the `network-only` request policy. This ensures that all GraphQL queries made through this client bypass its cache and fetch fresh data from the network, resolving the stale data issue.

Manual testing is recommended to confirm the fix and check for any performance implications.